### PR TITLE
Fix log app requests only for admins

### DIFF
--- a/opengluck-server/opengluck/http_request_log_route.py
+++ b/opengluck-server/opengluck/http_request_log_route.py
@@ -3,12 +3,12 @@ import json
 from flask import Response
 
 from .http_request_log import get_last_http_requests
-from .login import assert_current_request_logged_in
+from .login import assert_current_request_is_logged_in_as_admin
 from .server import app
 
 
 @app.route("/opengluck/last-requests")
 def _last_requests():
-    assert_current_request_logged_in()
+    assert_current_request_is_logged_in_as_admin()
     last_http_requests = get_last_http_requests()
     return Response(json.dumps(last_http_requests))

--- a/opengluck-server/opengluck/login.py
+++ b/opengluck-server/opengluck/login.py
@@ -248,6 +248,17 @@ def is_current_request_logged_in() -> bool:
     return True
 
 
+def is_current_request_logged_in_as_admin() -> bool:
+    """Checks if the current request is logged in as an admin."""
+    if not is_current_request_logged_in():
+        return False
+    token = get_current_request_token()
+    assert token
+    scope = get_token_scope(token)
+    if scope != "admin":
+        return False
+    return True
+
 def assert_current_request_logged_in() -> None:
     """Asserts that the current request is logged in."""
     if not is_current_request_logged_in():

--- a/opengluck-server/opengluck/server.py
+++ b/opengluck-server/opengluck/server.py
@@ -22,7 +22,8 @@ def is_app_request() -> bool:
 
 def _process_request():
     log_request_to_redis()
-    from .login import is_current_request_logged_in
+    from opengluck.login import is_current_request_logged_in_as_admin
+
     from .webhooks import call_webhooks
 
     try:
@@ -39,7 +40,7 @@ def _process_request():
         "data": data,
     }
 
-    if is_current_request_logged_in():
+    if is_current_request_logged_in_as_admin():
         call_webhooks("app_request", payload)
 
 


### PR DESCRIPTION
We don't need to log extensively app requests for normal users