### PR TITLE
Fix /app/data directory permission

### DIFF
--- a/opengluck-server/Dockerfile
+++ b/opengluck-server/Dockerfile
@@ -50,4 +50,5 @@ USER opengluck
 FROM app
 COPY --from=builder --chown=opengluck:opengluck /app/app/node_modules/.next/standalone /app/app
 COPY --from=builder --chown=opengluck:opengluck /app/app/node_modules/.next/static /app/app/node_modules/.next/static
+RUN mkdir -p /app/data && chown opengluck:opengluck /app/data
 USER opengluck


### PR DESCRIPTION
On certain cases the directory was owned by `root` which prevented OpenGlück from starting.
